### PR TITLE
Update tags according to Vim's :helptags output

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,3 +1,1 @@
-g:wwdc16_transp_bg	wwdc16.txt	/*g:wwdc16_transp_bg*
-wwdc16-options	wwdc16.txt	/*wwdc16-options*
-wwdc16.txt	wwdc16.txt	/*wwdc16.txt*
+vitaminonec.txt	vitaminonec.txt	/*vitaminonec.txt*


### PR DESCRIPTION
Run`:helptags /path/to/package/vim-vitamin-onec/doc/` to generate correct help tags. The current help tags match upstream
`lifepillar/vim-wwdc16-theme`.

This can possibly break plugin managers that run `:helptags ALL` during an update (e.g. `paq`).

